### PR TITLE
Added domain to scope

### DIFF
--- a/playbooks/files/get_token.py
+++ b/playbooks/files/get_token.py
@@ -2,7 +2,6 @@
 
 import openstack
 
-
 conn = openstack.connect()
 
 token = conn.identity.post(
@@ -25,7 +24,10 @@ token = conn.identity.post(
             },
             "scope": {
                 "project": {
-                    "name": conn.auth['project_name']
+                    "name": conn.auth['project_name'], 
+                    "domain": {
+                        "name": conn.auth['user_domain_name']
+                    }
                 }
             }
         }
@@ -46,8 +48,11 @@ token_from_token = conn.identity.post(
             },
             "scope": {
                "project": {
-                   "name": conn.auth['project_name']
-               }
+                   "name": conn.auth['project_name'],
+                   "domain": {
+                       "name": conn.auth['user_domain_name']
+                   }
+                }
               }
           }
     },


### PR DESCRIPTION
As we use also customer domains we need to add the domain to the scope. Otherwise the script fails with a key error:

```
Traceback (most recent call last):
  File "/Users/cstelter/Work/cloudmon/apimon-tests/playbooks/files/./get_token.py", line 37, in <module>
    token_id = token.headers['X-Subject-Token']
  File "/Users/cstelter/Work/cloudmon/apimon-tests/.test/lib/python3.9/site-packages/requests/structures.py", line 52, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'x-subject-token'
```

Solution by @nerdicbynature